### PR TITLE
Flask application naming consistency

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,15 +10,15 @@ days = [
     {"id": 7, "name": "Sunday"},
 ]
 
-api = Flask(__name__)
+app = Flask(__name__)
 
 
-@api.route("/", methods=["GET"])
+@app.route("/", methods=["GET"])
 def get_days():
     return jsonify(days)
 
 
-@api.route("/<int:day_id>", methods=["GET"])
+@app.route("/<int:day_id>", methods=["GET"])
 def get_day(day_id):
     day = [day for day in days if day["id"] == day_id]
     if len(day) == 0:
@@ -26,7 +26,7 @@ def get_day(day_id):
     return jsonify({"day": day[0]})
 
 
-@api.route("/", methods=["POST"])
+@app.route("/", methods=["POST"])
 def post_days():
     return jsonify({"success": True}), 201
 


### PR DESCRIPTION
Python invokes run function of class <flask.app.Flask> with object name "app":

https://github.com/mransbro/python-api/blob/74e7129d04909abbd9c37bf53635e9e416a6590d/app.py#L34-L35

However, the initialization of the object intended was named "api" rather than "app".

https://github.com/mransbro/python-api/blob/74e7129d04909abbd9c37bf53635e9e416a6590d/app.py#L13

The commit 4a164a9f52e37caea8647f6fcef0788dbe4b27ef resolves this inconsistent object naming by refactoring the code to have class <flask.app.Flask> with object name "api" be named "app". 

With consistent names, the NameError exception case is resolved. 

```Traceback (most recent call last):
  File "c:\Users\dmoruzzi\Documents\GitHub\python-api\app.py", line 35, in <module>
    app.run(debug=True)
NameError: name 'app' is not defined. Did you mean: 'api'?`
